### PR TITLE
Reindex with Sharding

### DIFF
--- a/.config
+++ b/.config
@@ -32,10 +32,10 @@ BATCH_ERROR_NODES_NUM=1000
 
 # SOLR SHARDING CONFIG, uncomment only if you want to enable
 # Set SHARD as any one of the shards that lives in SOLRURL (doesn't impact the results which one you choose)
-SHARD=alfresco-0
-SHARDLIST="http://solr61:8983/solr/alfresco-0,http://solr61:8983/solr/alfresco-1,http://solr62:8983/solr/alfresco-2,http://solr62:8983/solr/alfresco-3"
-SOLR_INSTANCE_LIST="http://localhost:8083/solr,http://localhost:8084/solr"
-PARALLEL_FIX=true
+#SHARD=alfresco-0
+#SHARDLIST="http://solr61:8983/solr/alfresco-0,http://solr61:8983/solr/alfresco-1,http://solr62:8983/solr/alfresco-2,http://solr62:8983/solr/alfresco-3"
+#SOLR_INSTANCE_LIST="http://localhost:8083/solr,http://localhost:8084/solr"
+#PARALLEL_FIX=true
 
 #Folder that will contain the exported and digested files that support the script
 BASEFOLDER=index_check
@@ -47,4 +47,4 @@ DEFAULT_QUERY_STRATEGY="node-id"
 CSV_FILENAME=output.csv
 
 # Reindex txn on missing node
-REINDEX_RELATED_TXNS=true
+REINDEX_RELATED_TXNS=false

--- a/.config
+++ b/.config
@@ -6,8 +6,8 @@ DBPASS=alfresco
 DBHOST=localhost
 
 # mySQL
-#DBMS=mysql
-#DBPORT=3306
+DBMS=mysql
+DBPORT=3306
 
 # Postgres
 #DBMS=pg
@@ -32,8 +32,9 @@ BATCH_ERROR_NODES_NUM=1000
 
 # SOLR SHARDING CONFIG, uncomment only if you want to enable
 # Set SHARD as any one of the shards that lives in SOLRURL (doesn't impact the results which one you choose)
-#SHARD=shard-0
-#SHARDLIST="http://solr6:8983/solr/shard-0,http://solr6:8983/solr/shard-1,http://solr6:8983/solr/shard-2"
+#SHARD=alfresco-0
+#SHARDLIST="http://solr61:8983/solr/alfresco-0,http://solr61:8983/solr/alfresco-1,http://solr62:8983/solr/alfresco-2,http://solr62:8983/solr/alfresco-3"
+#SOLR_INSTANCE_LIST="http://localhost:8083/solr,http://localhost:8084/solr"
 
 #Folder that will contain the exported and digested files that support the script
 BASEFOLDER=index_check

--- a/.config
+++ b/.config
@@ -32,9 +32,10 @@ BATCH_ERROR_NODES_NUM=1000
 
 # SOLR SHARDING CONFIG, uncomment only if you want to enable
 # Set SHARD as any one of the shards that lives in SOLRURL (doesn't impact the results which one you choose)
-#SHARD=alfresco-0
-#SHARDLIST="http://solr61:8983/solr/alfresco-0,http://solr61:8983/solr/alfresco-1,http://solr62:8983/solr/alfresco-2,http://solr62:8983/solr/alfresco-3"
-#SOLR_INSTANCE_LIST="http://localhost:8083/solr,http://localhost:8084/solr"
+SHARD=alfresco-0
+SHARDLIST="http://solr61:8983/solr/alfresco-0,http://solr61:8983/solr/alfresco-1,http://solr62:8983/solr/alfresco-2,http://solr62:8983/solr/alfresco-3"
+SOLR_INSTANCE_LIST="http://localhost:8083/solr,http://localhost:8084/solr"
+PARALLEL_FIX=true
 
 #Folder that will contain the exported and digested files that support the script
 BASEFOLDER=index_check
@@ -44,3 +45,6 @@ DEFAULT_QUERY_STRATEGY="node-id"
 
 #Default CSV file that will either be generated or needs to be provided. Can also be overriten as argument on --check
 CSV_FILENAME=output.csv
+
+# Reindex txn on missing node
+REINDEX_RELATED_TXNS=true

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ How to run:
 | --to or -t | final value to execute the query to - default is none|
 | --max or -m | limit the number of results - default no limit|
 | --check or -c | Will cross check the DB data from the default CSV or from the one provided as argument with the SOLR index. Outputs to screen the number of missing items in index and you can find the full list of missing items inside folder $BASEFOLDER. Will also do a check in SOLR for the error nodes and add them to the missing-nodes when not already there|
-| --check-errors-only | Will only gather the error nodes reported in SOLR. Does not need any prior actions and only requires a connection to SOLR. You can then (or simultaneosly)  use the --fix command to reindex these nodes|
+| --check-errors | Will gather the error nodes reported in SOLR. Can be used along with --check. Does not need any prior actions and only requires a connection to SOLR. You can then (or simultaneosly) use the --fix command to reindex these nodes|
 | --csv | Path to the CSV file you want to use to perform the cross check instead of using --query|
 | --fix | Reindexes the missing items. Requires that the check was ran previously and it relies on the files in $BASEFOLDER to request a reindex for each item|
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Only uncomment/include these configs if you have sharding
 | Variable | Example | Description |
 | ----------- | ----------- | ----------- |
 | SHARD | SHARD=shard-0 | Set SHARD as any one of the shards that lives in SOLRURL (doesn't impact the results which one you choose)|
-| SHARDLIST | SHARDLIST="<http://solr6:8983/solr/shard-0,http://solr6:8983/solr/shard-1,http://solr6:8983/solr/shard-2>" | A list of all shards we need to query|
+| SHARDLIST | SHARDLIST="<http://solr6:8983/solr/shard-0,http://solr6:8983/solr/shard-1,http://solr6:8983/solr/shard-2>" | A list of all shards we need to query - the URIs that SOLR is able to use to query the other shards/instances|
+| SOLR_INSTANCE_LIST | SHARDLIST="<http://localhost:8983/solr,http://localhost:8984/solr>" | A list of all instances we need to fix - the URIs that the script will call to fix|
+| PARALLEL_FIX | PARALLEL_FIX=true | Will issue the reindex to each instance in parallel, as a background process for each instance|
 
 ### Other configurations
 
@@ -66,6 +68,8 @@ Only uncomment/include these configs if you have sharding
 | DEFAULT_FROM_VALUE | DEFAULT_FROM_VALUE=0 | When no --from is provided, this is the default value we will query from|
 | DEFAULT_QUERY_STRATEGY | DEFAULT_QUERY_STRATEGY="node-id" | Default query strategy when no other is provided. Possible query strategies are: node-id (query by node DB ID), transaction-id (query by transaction ID) and transaction-committimems (query by the transaction commit time in milliseconds)|
 | CSV_FILE_NAME | CSV_FILE_NAME=output.csv | Default query strategy when no other is provided. Possible query strategies are: node-id (query by node DB ID), transaction-id (query by transaction ID) and transaction-committimems (query by the transaction commit time in milliseconds)|
+| REINDEX_RELATED_TXNS | REINDEX_RELATED=true | Option to also reindex the transactions related to the missing nodes|
+
 
 ## Usage
 


### PR DESCRIPTION
 - In order to reindex, the reindex action needs to be performed in each instance of SOLR. 
 - Added configuration SOLR_INSTANCE_LIST where you must list your solr instances - the script will call these directly
 - The reindex on each instance can be done in sequence (all requests to instance 1, then to instance 2, etc) or in parallel. Control this by setting PARALLEL_FIX=true. If set to perform the fix in parallel, the fix command will be issued to be done in background for each and you can see the result in the log file parallel-fix.log
 - Added option to be able to also reindex the transactions where the missing nodes belong to. Set REINDEX_RELATED_TXNS=true
 - Error check is no longer executed by default. If you want to also check errors you need to execute --check-errors