### PR TITLE
Option to disable transaction and changeset reindex

### DIFF
--- a/.config
+++ b/.config
@@ -1,28 +1,33 @@
-#Configure database before running the script if you want the script to run the query
+#
+# Database configuration
+#
 
-DBNAME=alfresco
-DBUSER=alfresco
-DBPASS=alfresco
-DBHOST=localhost
-
-# mySQL
+# Database - Possible values are mysql, pg, ora
 DBMS=mysql
+# Database name
+DBNAME=alfresco
+# Database username
+DBUSER=alfresco
+# Database password
+DBPASS=alfresco
+# Database host
+DBHOST=localhost
+# Database port
 DBPORT=3306
 
-# Postgres
-#DBMS=pg
-#DBPORT=5432
-
-# Oracle
-#DBMS=ora
-#DBPORT=1521
-#DBSID=PDB1
-
+#
 # SOLR Config
+#
+
+# Solr URI
 SOLRURL=http://localhost:8083/solr
+# Solr Secret
 SOLRSECRET=secret
+# Number of nodes to check in each request
 BATCH_REQUEST_NUM=100
+# Limit the results for error nodes in each request
 BATCH_ERROR_NODES_NUM=1000
+# Limit the results for children nodes in each request
 BATCH_CHILD_NODES_NUM=1000
 
 # SOLR SSL Config, uncomment only if you want to enable
@@ -34,18 +39,30 @@ BATCH_CHILD_NODES_NUM=1000
 # SOLR SHARDING CONFIG, uncomment only if you want to enable
 # Set SHARD as any one of the shards that lives in SOLRURL (doesn't impact the results which one you choose)
 #SHARD=alfresco-0
+# Comma separated list of all shards
 #SHARDLIST="http://solr61:8983/solr/alfresco-0,http://solr61:8983/solr/alfresco-1,http://solr62:8983/solr/alfresco-2,http://solr62:8983/solr/alfresco-3"
+# Comma separated list of all SOLR instances
 #SOLR_INSTANCE_LIST="http://localhost:8083/solr,http://localhost:8084/solr"
+# When you perform the fix operation, the requests will be sent to all shards in parallel instead of sequentially
 #PARALLEL_FIX=true
 
-#Folder that will contain the exported and digested files that support the script
+#
+# Other Configuraction
+#
+
+# Folder that will contain the exported and digested files that support the script
 BASEFOLDER=index_check
 
+# When performing a query, the default value for the from parameter
 DEFAULT_FROM_VALUE=0
+# Default query strategy to use when querying SOLR. Possible values are node-id, transaction-id, transaction-committimems and ancestor-id
 DEFAULT_QUERY_STRATEGY="node-id"
 
-#Default CSV file that will either be generated or needs to be provided. Can also be overriten as argument on --check
+# Default CSV file that will either be generated or needs to be provided. 
 CSV_FILENAME=output.csv
 
-# Reindex txn on missing node
+# Also reindex txn on missing node even if the transaction is not missing
 REINDEX_RELATED_TXNS=false
+
+# Disable transaction and changeset reindexing
+TX_REINDEX_ENABLED=true

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,0 +1,10 @@
+# Alfresco Search Services Inspector Script Change Log
+
+* 2022-12: Initial version
+* 2023-01: Bugfix - Fix missing solr headers
+* 2024-06: Bugfix - Fix cross-check not being executed by exact match
+* 2024-10: Feature - Added ability to check and fix error nodes in SOLR. Does the check by default on --check. Can be run in standalone by doing --check-errors-only
+* 2025-02: Bugfix - When reindexing nodes with mutiple shards across multiple instances, the action needs to be performed in each SOLR instance. Added configurations: SOLR_INSTANCE_LIST, PARALLEL_FIX and REINDEX_RELATED_TXNS.
+* 2025-02: Feature - Check Errors is no longer executed by default. To check errors you need to do --check-errors
+* 2025-02: Feature - Check and Fix nodes in path. Added strategy "ancestor-id" and config variable BATCH_CHILD_NODES_NUM
+* 2025-02: Feature - Added configuration TX_REINDEX_ENABLED so we can turn off reindexing missing transactions and changesets even if detected - in sharded envs since the reindex needs to be done in each instance, this seems to add all documents from the transaction to each shard - so we need to turn it off.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Only uncomment/include these configs if you have sharding
 | DEFAULT_QUERY_STRATEGY | DEFAULT_QUERY_STRATEGY="node-id" | Default query strategy when no other is provided. Possible query strategies are: node-id (query by node DB ID), transaction-id (query by transaction ID) and transaction-committimems (query by the transaction commit time in milliseconds)|
 | CSV_FILE_NAME | CSV_FILE_NAME=output.csv | Default query strategy when no other is provided. Possible query strategies are: node-id (query by node DB ID), transaction-id (query by transaction ID) and transaction-committimems (query by the transaction commit time in milliseconds)|
 | REINDEX_RELATED_TXNS | REINDEX_RELATED=true | Option to also reindex the transactions related to the missing nodes|
+| TX_REINDEX_ENABLED | TX_REINDEX_ENABLED=true | Option to enable/disable reindexing missing transactions and changesets|
 
 
 ## Usage

--- a/checkIndex.sh
+++ b/checkIndex.sh
@@ -16,6 +16,7 @@ DEFAULT_QUERY_STRATEGY="node-id"
 CSV_FILENAME=output.csv
 REINDEX_RELATED_TXNS=false
 PARALLEL_FIX=false
+TX_REINDEX_ENABLED=true
 
 displayHelp()
 {
@@ -327,9 +328,14 @@ fix()
         SECONDS=0
         fixItem "nodes" "nodeid" "$SHARDINSTANCE"
         fixACLs "$SHARDINSTANCE"
-        fixItem "txns" "txid" "$SHARDINSTANCE"
-        fixItem "acltxids" "acltxid" "$SHARDINSTANCE"
-        purgeNodes "$SHARDINSTANCE"
+
+        if [ "$TX_REINDEX_ENABLED" == "true" ]; then
+            fixItem "txns" "txid" "$SHARDINSTANCE"
+            fixItem "acltxids" "acltxid" "$SHARDINSTANCE"
+        fi
+        if [ "$QUERY_STRATEGY" == "ANCESTOR-ID" ]; then
+            purgeNodes "$SHARDINSTANCE"
+        fi
         sucessMsg "Elapsed Time requesting reindex in instance $SHARDINSTANCE: $SECONDS seconds"
     done
 }
@@ -971,8 +977,6 @@ if [ "$RUN_FIX" -eq 1 ]; then
         fix
     fi
 fi
-
-
 
 if [ "$RUN_QUERY" -eq 0 ] && [ "$RUN_CHECK" = 0 ] && [ "$RUN_FIX" = 0 ] && [ "$RUN_ERROR_CHECK" = 0 ]; then
     displayHelp


### PR DESCRIPTION
* Added changelog
* Improved documentation of config file
* Added configuration TX_REINDEX_ENABLED so we can turn off reindexing missing transactions and changesets even if detected - in sharded envs since the reindex needs to be done in each instance, this seems to add all documents from the transaction to each shard - so we need to turn it off.